### PR TITLE
Upgrade import dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "eslint": "^3.3.1",
     "eslint-plugin-better": "^0.1.5",
     "eslint-plugin-fp": "^2.2.0",
-    "eslint-plugin-import": "^1.14.0"
+    "eslint-plugin-import": "^2.2.0"
   }
 }


### PR DESCRIPTION
Hi, I upgraded the eslint-plugin-import dependency because it was conflicting with some other peer dependencies. Been using it this week and haven't noticed any issues. Thanks.